### PR TITLE
Link to "old" linuxappsummit for now

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@ scripts:
         <div class="col-md-12">
           <div>
             <h2 class="u-fontMono toggle-hidden">Linux App Summit 2019</h2>
-            <a href="https://linuxappsummit.org/"><img src="https://linuxappsummit.org/assets/2019-LAS-hero.svg"></a>
+            <a href="https://2019.linuxappsummit.org/"><img src="https://2019.linuxappsummit.org/assets/2019-LAS-hero.svg"></a>
           </div>
         </div>
     </div>


### PR DESCRIPTION
We need to probably remove this from the main page or reorganize a bit,
but at least make the links work