### PR TITLE
Responsive patron grid

### DIFF
--- a/_sass/_front.scss
+++ b/_sass/_front.scss
@@ -40,13 +40,12 @@ a:active {
     margin-bottom: 30px;
 }
 .patrons {
-    margin-bottom: 40px;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-row-gap: 2rem;
 }
 .patronLogo {
-    padding-left: 15px;
-    padding-right: 15px;
-    max-width: 20%;
-    max-height: 7em;
+    max-height: 9rem;
 }
 .closingText {
     font-size: 22px;
@@ -69,6 +68,16 @@ a:active {
 }
 ::-moz-selection {
     background: rgb(255, 255, 165);
+}
+
+
+@media screen and (min-width: $screen-md-min) {
+    .patrons {
+        margin: 0 auto;
+        margin-bottom: 4rem;
+        grid-template-columns: repeat(4, 1fr);
+        max-width: 800px;
+    }
 }
 
 @media screen and (min-width: $screen-lg-min) {


### PR DESCRIPTION
## before desktop
<img width="908" alt="imagen" src="https://user-images.githubusercontent.com/1236790/116157302-04a03400-a6ed-11eb-8998-fbb8258c3a04.png">

## after desktop
<img width="862" alt="imagen" src="https://user-images.githubusercontent.com/1236790/116157316-0bc74200-a6ed-11eb-9ad6-7f88ca0468f5.png">

## before mobile
<img width="337" alt="imagen" src="https://user-images.githubusercontent.com/1236790/116157344-1d104e80-a6ed-11eb-86fd-aefdbfd18181.png">

## after mobile
<img width="336" alt="imagen" src="https://user-images.githubusercontent.com/1236790/116157367-27324d00-a6ed-11eb-8819-bc50944ac49c.png">

