### PR TITLE
Remove opensuse and pine sponsoring links

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,8 +25,6 @@ layout: default
         <div class="patrons">
           <a class="u-zeroDecoration" href="https://www.kde.org/"><img class="patronLogo" alt="KDE España" src="images/kde.svg"></a>
           <a class="u-zeroDecoration" href="https://www.fsfe.org/"><img class="patronLogo" alt="Free Software Foundation Europe" src="images/fsfe.svg"></a>
-          <a class="u-zeroDecoration" href="https://www.opensuse.org/"><img class="patronLogo" alt="Suse" src="images/openSUSE_logo.svg"></a>
-          <a class="u-zeroDecoration" href="https://www.pine64.org/"><img class="patronLogo" alt="Suse" src="images/pine64.jpg"></a>
         </div>
         <hr />
         <p class="closingText">Want to help us? We have <a href="/sponsoring">sponsorships</a> available.</p>


### PR DESCRIPTION
They last sponsored in 2019 and 2020